### PR TITLE
fix(extract): authenticate /extract and /general with workspace JWT and harden parsers

### DIFF
--- a/prepline_general/api/auth.py
+++ b/prepline_general/api/auth.py
@@ -1,0 +1,23 @@
+import os
+import secrets
+
+from fastapi import HTTPException, Request, status
+
+
+def require_api_key(request: Request) -> None:
+    """Enforce the shared internal API key.
+
+    Parity with the /general endpoint: when UNSTRUCTURED_API_KEY is unset the
+    check is a no-op so local/dev deployments keep working. When set, requests
+    must present a matching `unstructured-api-key` header.
+    """
+    api_key_env = os.environ.get("UNSTRUCTURED_API_KEY")
+    if not api_key_env:
+        return
+
+    provided = request.headers.get("unstructured-api-key") or ""
+    if not secrets.compare_digest(provided, api_key_env):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or missing API key",
+        )

--- a/prepline_general/api/auth.py
+++ b/prepline_general/api/auth.py
@@ -1,23 +1,65 @@
 import os
-import secrets
 
+import jwt
 from fastapi import HTTPException, Request, status
 
+# Issuers minted by the orq platform. Mirrors the issuer handling in
+# libs/go/fiber/middlewares/jwt.go (VerifyOrqToken) and the python-runner
+# validate_jwt_token helper: service tokens use `orq.internal`, external API
+# keys use `orq`/`orq.ai`, and user sessions use `kratos`.
+_ALLOWED_ISSUERS = frozenset({"orq.internal", "orq.ai", "orq", "kratos"})
 
-def require_api_key(request: Request) -> None:
-    """Enforce the shared internal API key.
 
-    Parity with the /general endpoint: when UNSTRUCTURED_API_KEY is unset the
-    check is a no-op so local/dev deployments keep working. When set, requests
-    must present a matching `unstructured-api-key` header.
-    """
-    api_key_env = os.environ.get("UNSTRUCTURED_API_KEY")
-    if not api_key_env:
-        return
-
-    provided = request.headers.get("unstructured-api-key") or ""
-    if not secrets.compare_digest(provided, api_key_env):
+def _bearer_token(request: Request) -> str:
+    header = request.headers.get("authorization") or ""
+    parts = header.split()
+    if len(parts) != 2 or parts[0].lower() != "bearer":
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid or missing API key",
+            detail="Missing or malformed Authorization header",
         )
+    return parts[1]
+
+
+def require_orq_workspace(request: Request) -> str:
+    """Verify an orq-platform JWT and return its workspace id.
+
+    Replaces the shared static `UNSTRUCTURED_API_KEY` with the same token
+    contract the rest of the platform uses: an HS256 signature over
+    `JWT_SECRET` plus an allow-listed issuer. The verified `workspace_id`
+    claim is returned so callers can scope storage lookups to the
+    authenticated tenant (closes the /extract IDOR). There is no static-key
+    fallback — every caller must present a workspace-scoped bearer token.
+    """
+    secret = os.environ.get("JWT_SECRET")
+    if not secret:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Service authentication is not configured",
+        )
+
+    token = _bearer_token(request)
+    try:
+        claims = jwt.decode(token, secret, algorithms=["HS256"])
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Token has expired"
+        )
+    except jwt.InvalidTokenError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+        )
+
+    if claims.get("iss") not in _ALLOWED_ISSUERS:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Untrusted token issuer"
+        )
+
+    workspace_id = claims.get("workspace_id") or claims.get("workspaceId")
+    if not workspace_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Token is missing workspace scope",
+        )
+
+    return workspace_id

--- a/prepline_general/api/config/database_config.py
+++ b/prepline_general/api/config/database_config.py
@@ -15,6 +15,7 @@ class FileDocument(TypedDict):
     bytes: int
     file_name: str
     file_id: str
+    workspace_id: str
 
 # Synchronous function
 def get_database() -> Collection[FileDocument]:

--- a/prepline_general/api/general.py
+++ b/prepline_general/api/general.py
@@ -19,6 +19,7 @@ import psutil
 import requests
 import tiktoken
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request, UploadFile, status
+from .auth import require_orq_workspace
 from fastapi.responses import PlainTextResponse, StreamingResponse
 from pypdf import PageObject, PdfReader, PdfWriter
 from pypdf.errors import FileNotDecryptedError, PdfReadError
@@ -750,15 +751,8 @@ def general_partition(
     # For new parameters - add them in models/form_params.py
     files: List[UploadFile],
     form_params: GeneralFormParams = Depends(GeneralFormParams.as_form),
+    workspace_id: str = Depends(require_orq_workspace),
 ):
-    # -- must have a valid API key --
-    if api_key_env := os.environ.get("UNSTRUCTURED_API_KEY"):
-        api_key = request.headers.get("unstructured-api-key")
-        if api_key != api_key_env:
-            raise HTTPException(
-                detail=f"API key {api_key} is invalid", status_code=status.HTTP_401_UNAUTHORIZED
-            )
-
     accept_type = request.headers.get("Accept")
 
     # -- detect response content-type conflict when multiple files are uploaded --

--- a/prepline_general/api/pdf_extractor.py
+++ b/prepline_general/api/pdf_extractor.py
@@ -4,7 +4,7 @@ import tempfile
 import os
 import sentry_sdk
 
-from .auth import require_api_key
+from .auth import require_orq_workspace
 from .storage.storage_client import StorageClient
 from .config.database_config import get_database, FileDocument
 import logging
@@ -61,14 +61,15 @@ def extract_file_content(file: BinaryIO, content_type: str) -> str:
     return content
 
 
-@router.post("", dependencies=[Depends(require_api_key)])
+@router.post("")
 async def get_pdf_content(
     request: FileIdRequest = Body(...),
     storage_client: StorageClient = Depends(get_storage_client),
     db: Collection[FileDocument] = Depends(get_database),
+    workspace_id: str = Depends(require_orq_workspace),
 ):
     try:
-        file_doc = db.find_one({"_id": request.file_id})
+        file_doc = db.find_one({"_id": request.file_id, "workspace_id": workspace_id})
 
         if not file_doc:
             raise HTTPException(status_code=404, detail="File not found in database")
@@ -100,6 +101,9 @@ async def get_pdf_content(
         os.unlink(temp_file.name)  # Delete the temporary file
 
         return {"content": content, "file_id": request.file_id, "file_name": file_name, "object_name": object_name}
+    except HTTPException:
+        # 404/400 (including cross-tenant denial) are deliberate — don't mask as 500.
+        raise
     except Exception as e:
         sentry_sdk.capture_message("Error processing PDF")
         sentry_sdk.capture_exception(e)

--- a/prepline_general/api/pdf_extractor.py
+++ b/prepline_general/api/pdf_extractor.py
@@ -2,6 +2,9 @@ import mimetypes
 from fastapi import APIRouter, HTTPException, Depends, Body
 import tempfile
 import os
+import sentry_sdk
+
+from .auth import require_api_key
 from .storage.storage_client import StorageClient
 from .config.database_config import get_database, FileDocument
 import logging
@@ -58,7 +61,7 @@ def extract_file_content(file: BinaryIO, content_type: str) -> str:
     return content
 
 
-@router.post("")
+@router.post("", dependencies=[Depends(require_api_key)])
 async def get_pdf_content(
     request: FileIdRequest = Body(...),
     storage_client: StorageClient = Depends(get_storage_client),

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -25,3 +25,4 @@ sentry-sdk[fastapi]
 python-dotenv
 nats-py
 python-ulid
+PyJWT>=2.8.0

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,5 +1,5 @@
 -c constraints.in
-unstructured[all-docs]
+unstructured[all-docs]>=0.18.18
 # Pinning click due to a unicode issue in black
 # can remove after black drops support for Python 3.6
 # ref: https://github.com/psf/black/issues/2964
@@ -13,7 +13,7 @@ uvicorn
 ratelimit
 requests
 backoff
-pypdf
+pypdf>=6.9.2
 pycryptodome
 psutil
 pypdfium2

--- a/test_general/api/test_app.py
+++ b/test_general/api/test_app.py
@@ -12,8 +12,11 @@ from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from pypdf import PdfReader, PdfWriter
 
+import jwt
+
 from prepline_general.api import general
 from prepline_general.api.app import app
+from prepline_general.api.auth import require_orq_workspace
 
 MAIN_API_ROUTE = "general/v0/general"
 
@@ -519,31 +522,33 @@ def test_general_api_returns_503(monkeypatch):
     assert response.status_code == 503
 
 
-def test_general_api_returns_401(monkeypatch):
-    """
-    When UNSTRUCTURED_API_KEY is set, return a 401 if the unstructured-api-key header does not match
-    """
-    monkeypatch.setenv("UNSTRUCTURED_API_KEY", "foobar")
+def test_general_requires_valid_jwt():
+    """/general rejects requests without a valid orq workspace JWT and accepts a signed one."""
+    # Exercise the real dependency (conftest overrides it for other tests).
+    app.dependency_overrides.pop(require_orq_workspace, None)
 
     client = TestClient(app)
     test_file = Path("sample-docs") / "fake-xml.xml"
+
+    # No token -> 401
     response = client.post(
         MAIN_API_ROUTE,
         files=[("files", (str(test_file), open(test_file, "rb")))],
-        headers={"unstructured-api-key": "foobar"},
     )
-
-    assert response.status_code == 200
-
-    client = TestClient(app)
-    test_file = Path("sample-docs") / "fake-xml.xml"
-    response = client.post(
-        MAIN_API_ROUTE,
-        files=[("files", (str(test_file), open(test_file, "rb")))],
-        headers={"unstructured-api-key": "helloworld"},
-    )
-
     assert response.status_code == 401
+
+    # Valid workspace-scoped token -> 200
+    token = jwt.encode(
+        {"iss": "orq.internal", "workspace_id": "ws_test"},
+        os.environ["JWT_SECRET"],
+        algorithm="HS256",
+    )
+    response = client.post(
+        MAIN_API_ROUTE,
+        files=[("files", (str(test_file), open(test_file, "rb")))],
+        headers={"authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
 
 
 class MockResponse:

--- a/test_general/api/test_extract_auth.py
+++ b/test_general/api/test_extract_auth.py
@@ -1,0 +1,35 @@
+"""Auth tests for the /extract endpoint dependency (require_api_key)."""
+
+import pytest
+from fastapi import HTTPException
+
+from prepline_general.api.auth import require_api_key
+
+
+class _StubRequest:
+    def __init__(self, headers):
+        self.headers = headers
+
+
+def test_no_key_configured_is_noop(monkeypatch):
+    monkeypatch.delenv("UNSTRUCTURED_API_KEY", raising=False)
+    require_api_key(_StubRequest({}))
+
+
+def test_missing_key_rejected(monkeypatch):
+    monkeypatch.setenv("UNSTRUCTURED_API_KEY", "secret")
+    with pytest.raises(HTTPException) as exc:
+        require_api_key(_StubRequest({}))
+    assert exc.value.status_code == 401
+
+
+def test_wrong_key_rejected(monkeypatch):
+    monkeypatch.setenv("UNSTRUCTURED_API_KEY", "secret")
+    with pytest.raises(HTTPException) as exc:
+        require_api_key(_StubRequest({"unstructured-api-key": "nope"}))
+    assert exc.value.status_code == 401
+
+
+def test_correct_key_accepted(monkeypatch):
+    monkeypatch.setenv("UNSTRUCTURED_API_KEY", "secret")
+    require_api_key(_StubRequest({"unstructured-api-key": "secret"}))

--- a/test_general/api/test_extract_auth.py
+++ b/test_general/api/test_extract_auth.py
@@ -1,9 +1,14 @@
-"""Auth tests for the /extract endpoint dependency (require_api_key)."""
+"""Unit tests for require_orq_workspace (orq platform JWT verification)."""
 
+import time
+
+import jwt
 import pytest
 from fastapi import HTTPException
 
-from prepline_general.api.auth import require_api_key
+from prepline_general.api.auth import require_orq_workspace
+
+SECRET = "unit-test-secret"
 
 
 class _StubRequest:
@@ -11,25 +16,68 @@ class _StubRequest:
         self.headers = headers
 
 
-def test_no_key_configured_is_noop(monkeypatch):
-    monkeypatch.delenv("UNSTRUCTURED_API_KEY", raising=False)
-    require_api_key(_StubRequest({}))
+@pytest.fixture(autouse=True)
+def _set_secret(monkeypatch):
+    monkeypatch.setenv("JWT_SECRET", SECRET)
 
 
-def test_missing_key_rejected(monkeypatch):
-    monkeypatch.setenv("UNSTRUCTURED_API_KEY", "secret")
+def _token(secret=SECRET, **overrides):
+    payload = {"iss": "orq.internal", "workspace_id": "ws_1"}
+    payload.update(overrides)
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+def _req(authorization=None):
+    headers = {}
+    if authorization is not None:
+        headers["authorization"] = authorization
+    return _StubRequest(headers)
+
+
+def test_valid_token_returns_workspace_id():
+    assert require_orq_workspace(_req(f"Bearer {_token()}")) == "ws_1"
+
+
+def test_missing_header_rejected():
     with pytest.raises(HTTPException) as exc:
-        require_api_key(_StubRequest({}))
+        require_orq_workspace(_req())
     assert exc.value.status_code == 401
 
 
-def test_wrong_key_rejected(monkeypatch):
-    monkeypatch.setenv("UNSTRUCTURED_API_KEY", "secret")
+def test_malformed_header_rejected():
     with pytest.raises(HTTPException) as exc:
-        require_api_key(_StubRequest({"unstructured-api-key": "nope"}))
+        require_orq_workspace(_req("Token abc"))
     assert exc.value.status_code == 401
 
 
-def test_correct_key_accepted(monkeypatch):
-    monkeypatch.setenv("UNSTRUCTURED_API_KEY", "secret")
-    require_api_key(_StubRequest({"unstructured-api-key": "secret"}))
+def test_bad_signature_rejected():
+    with pytest.raises(HTTPException) as exc:
+        require_orq_workspace(_req(f"Bearer {_token(secret='wrong-secret')}"))
+    assert exc.value.status_code == 401
+
+
+def test_untrusted_issuer_rejected():
+    with pytest.raises(HTTPException) as exc:
+        require_orq_workspace(_req(f"Bearer {_token(iss='evil')}"))
+    assert exc.value.status_code == 401
+
+
+def test_expired_token_rejected():
+    token = _token(exp=int(time.time()) - 10)
+    with pytest.raises(HTTPException) as exc:
+        require_orq_workspace(_req(f"Bearer {token}"))
+    assert exc.value.status_code == 401
+
+
+def test_token_without_workspace_rejected():
+    token = jwt.encode({"iss": "orq.internal"}, SECRET, algorithm="HS256")
+    with pytest.raises(HTTPException) as exc:
+        require_orq_workspace(_req(f"Bearer {token}"))
+    assert exc.value.status_code == 403
+
+
+def test_missing_secret_is_misconfiguration(monkeypatch):
+    monkeypatch.delenv("JWT_SECRET", raising=False)
+    with pytest.raises(HTTPException) as exc:
+        require_orq_workspace(_req(f"Bearer {_token()}"))
+    assert exc.value.status_code == 500

--- a/test_general/conftest.py
+++ b/test_general/conftest.py
@@ -1,0 +1,20 @@
+import os
+
+import pytest
+
+from prepline_general.api.app import app
+from prepline_general.api.auth import require_orq_workspace
+
+
+@pytest.fixture(autouse=True)
+def _bypass_orq_workspace_auth():
+    """Endpoint tests exercise document parsing, not auth, so override the
+    workspace dependency to a fixed tenant and make sure JWT_SECRET is set.
+
+    Auth itself is covered directly in test_extract_auth.py (the verifier) and
+    test_general_requires_valid_jwt (end-to-end through the client).
+    """
+    os.environ.setdefault("JWT_SECRET", "test-jwt-secret")
+    app.dependency_overrides[require_orq_workspace] = lambda: "ws_test"
+    yield
+    app.dependency_overrides.pop(require_orq_workspace, None)


### PR DESCRIPTION
## Authenticate /extract and /general with the orq workspace JWT

**Updated:** this PR now uses the platform's **workspace JWT** instead of the original static `UNSTRUCTURED_API_KEY`. The service verifies the same token contract as `libs/go/fiber/middlewares/jwt.go` (HS256 / `JWT_SECRET`, issuer allowlist `{orq.internal, orq.ai, orq, kratos}`). No shared static secret; both callers are backend (the frontend never calls unstructured).

### P1 — /extract auth + file_id IDOR
- `auth.py`: `require_orq_workspace()` verifies signature + issuer + expiry and returns the `workspace_id` claim (401 on bad/missing token; 403 if the token carries no workspace).
- `/extract` scopes the lookup — `find_one({_id, workspace_id})` — so a guessed/known file_id from another workspace returns 404. IDOR closed. Also fixed the `except` that masked deliberate 404/400 as 500. `FileDocument` gains `workspace_id`.
- `/general` now requires a valid workspace JWT (was an optional static key).

### P2 — parser hardening (unchanged in this PR)
- `pypdf>=6.9.2`, `unstructured[all-docs]>=0.18.18` floors in `requirements/base.in`. `process_attachments` stays default (`False`). Still TODO before merge: `make pip-compile` to regenerate the lock, and pin the Docker base image to a digest.

### Tests
- Verifier unit tests: valid / missing / malformed / bad-sig / bad-issuer / expired / no-workspace / no-secret — all pass locally.
- `conftest.py` overrides the dependency for the existing parsing tests; an e2e test asserts `/general` 401 without a token and 200 with a signed one.
- `PyJWT` added to `base.in`.

### Companion changes
- Callers send the token: [orq-ai/orquesta-web#9473](https://github.com/orq-ai/orquesta-web/pull/9473).
- unstructured needs `JWT_SECRET` (secretRef `common`) — orq-infra deployment edit (currently held as a working-tree change, not pushed).

### Deploy ordering
Ship the `JWT_SECRET` deployment change **and** the caller PR together with this — otherwise these calls 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
